### PR TITLE
Remove override of 'createJSModules' for RN 0.47

### DIFF
--- a/android/src/main/java/com/jadsonlourenco/RNShakeEvent/RNShakeEventPackage.java
+++ b/android/src/main/java/com/jadsonlourenco/RNShakeEvent/RNShakeEventPackage.java
@@ -23,7 +23,8 @@ public class RNShakeEventPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated RN 0.47
+    // @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Note: I realize this repo is discontinued, just creating this PR for posterity in case others still wish to use this or a fork in the future. This updates the library for the react-native 0.47 breaking change.

https://github.com/facebook/react-native/releases/tag/v0.47.0

This is not a breaking change for this library. Users can continue to update react-native-shake-event without being forced to update RN to >= 0.47. The downside to doing it this way instead of removing it is that there is now dead code for RN >= 0.47.