### PR TITLE
handler is not required. Mark it as such in flow

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -20,7 +20,7 @@ class RNShakeEvent {
       }
     });
   }
-  static removeEventListener(type: string, handler: Function) {
+  static removeEventListener(type: string, handler?: Function) {
     invariant(
       type === 'shake',
       'RNShakeEventIOS only supports `shake` event'


### PR DESCRIPTION
The current flow typing is showing a warning. The example code never ads a handler function
 componentWillUnmount() {
    RNShakeEvent.removeEventListener('shake');
  }

so I've marked the handler as optional